### PR TITLE
remove hardcoded logout url

### DIFF
--- a/src/services/keycloak.service.ts
+++ b/src/services/keycloak.service.ts
@@ -27,7 +27,7 @@ export class KeycloakService {
       return new Promise((resolve, reject) => {
         keycloakAuth.init({ onLoad: 'login-required', flow: 'implicit' }).success(() => {
           KeycloakService.auth.authz = keycloakAuth;
-          KeycloakService.auth.logoutUrl = keycloakAuth.authServerUrl + "/realms/keypress/protocol/openid-connect/logout?redirect_uri=/";
+          KeycloakService.auth.logoutUrl = keycloakAuth.authServerUrl + "/realms/" + keycloakConfig.realm + "/protocol/openid-connect/logout?redirect_uri=/";
           KeycloakService.enabled = true;
           resolve();
         }).error((err) => {


### PR DESCRIPTION
**Description**
Copying over a fix into this repo for a hardcoded logout can that can a crash/white screen when targeting a keycloak instance that doesn't have the `keypress` realm.