### PR TITLE
Add support for App ID and App Key headers

### DIFF
--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -42,13 +42,23 @@ const bootstrap = function() {
 
     Sync.manage('myShoppingList', null, {}, {}, () => {
       KeycloakService.init(keycloakConfig).then(() => {
+        const syncCloudUrl = syncConfig.uri + '/sync/';
+        var syncCloudHandler;
         if(keycloakConfig) {
-          const syncCloudUrl = syncConfig.uri + '/sync/';
-          const syncCloudHandler = buildSyncCloudHandler(syncCloudUrl, {
+          syncCloudHandler = buildSyncCloudHandler(syncCloudUrl, {
             headers: {
               'Authorization': 'Bearer ' + KeycloakService.auth.authz.token
             }
           });
+        } else if (syncConfig.app_id && syncConfig.app_key) {
+          syncCloudHandler = buildSyncCloudHandler(syncCloudUrl, {
+            headers: {
+              'app_id': syncConfig.app_id,
+              'app_key': syncConfig.app_key
+            }
+          });
+        }
+        if (syncCloudHandler) {
           Sync.setCloudHandler(syncCloudHandler);
         }
         const platform = platformBrowserDynamic();

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,4 +1,5 @@
 declare var require: any
+
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app.module';
 import { KeycloakService } from '../services/keycloak.service';
@@ -50,12 +51,10 @@ const bootstrap = function() {
               'Authorization': 'Bearer ' + KeycloakService.auth.authz.token
             }
           });
-        } else if (syncConfig.app_id && syncConfig.app_key) {
+        }
+        if (syncConfig.headers) {
           syncCloudHandler = buildSyncCloudHandler(syncCloudUrl, {
-            headers: {
-              'app_id': syncConfig.app_id,
-              'app_key': syncConfig.app_key
-            }
+            headers: syncConfig.headers
           });
         }
         if (syncCloudHandler) {


### PR DESCRIPTION
If the syncConfig sent back from MCP includes an `app_id` and `app_key`,
set these values in headers for all sync requests.
This change is pre-empting MCP Server changes in https://issues.jboss.org/browse/FH-4232